### PR TITLE
include headers and link lib for compilation on Windows systems

### DIFF
--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -20,6 +20,7 @@
 #include "ed25519-randombytes.h"
 #include "ed25519-hash.h"
 #include "Winsock2.h"
+#include "stdio.h"
 
 #define VARIANT_CODE
 

--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -19,6 +19,7 @@
 #include "ed25519.h"
 #include "ed25519-randombytes.h"
 #include "ed25519-hash.h"
+#include "Winsock2.h"
 
 #define VARIANT_CODE
 

--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -19,10 +19,11 @@
 #include "ed25519.h"
 #include "ed25519-randombytes.h"
 #include "ed25519-hash.h"
+#ifdef _WIN32
 #include "Winsock2.h"
 #include "stdio.h"
-
 #pragma comment(lib, "ws2_32.lib")
+#endif
 
 #define VARIANT_CODE
 

--- a/src/ed25519.c
+++ b/src/ed25519.c
@@ -22,6 +22,8 @@
 #include "Winsock2.h"
 #include "stdio.h"
 
+#pragma comment(lib, "ws2_32.lib")
+
 #define VARIANT_CODE
 
 /*


### PR DESCRIPTION
in order to `npm install` and compile BIP32-Ed25519 on Windows/NodeJS I had to include some header files and a library to fix

```
..\src\ed25519.c(167): warning C4013: 'htonl' undefined; assuming extern returning int [C:\Users\mgu\Documents\cwag\nod
e_modules\bip-ed25519\build\bip-ed25519.vcxproj]
..\src\ed25519.c(168): warning C4013: 'printf' undefined; assuming extern returning int [C:\Users\mgu\Documents\cwag\no
de_modules\bip-ed25519\build\bip-ed25519.vcxproj]
```
and
```
error LNK2001: unresolved external symbol htonl
```

Not sure if this breaks functionality on Linux systems or how to solve it in a general way.